### PR TITLE
Improves SRE option handling

### DIFF
--- a/bin/mjsre.js
+++ b/bin/mjsre.js
@@ -25,7 +25,7 @@ const argv = require("yargs")
     .options({
         speech: {
             boolean: true,
-            default: mj.options.speak,
+            default: mj.options.speakText,
             describe: "include speech text"
         },
         sre: {
@@ -93,6 +93,14 @@ const argv = require("yargs")
     })
     .argv;
 
+const formats = {
+  'commonhtml': 'html',
+  'mathml': 'mml',
+  'chtml': 'html'
+};
+
+argv.output = formats[argv.output] || argv.output;
+
 if (argv.font === "STIX") argv.font = "STIX-Web";
 if (argv.format === "TeX") argv.format = (argv.inline ? "inline-TeX" : "TeX");
 
@@ -108,14 +116,6 @@ const mjconf = {
     },
     extensions: argv.extensions
 };
-
-const outputFormats = {
-  'commonhtml': 'html',
-  'mathml': 'mml',
-  'chtml': 'html'
-};
-
-argv.output = outputFormats[argv.output] || argv.output;
 
 const mjinput = {
     math: argv._[0],

--- a/bin/mjsre.js
+++ b/bin/mjsre.js
@@ -33,14 +33,6 @@ const argv = require("yargs")
             nargs: 2,
             describe: "SRE flags as key value pairs"
         },
-        speechrules: { // deprecated
-            default: mj.options.speakRules,
-            describe: "ruleset to use for speech text (chromevox or mathspeak)"
-        },
-        speechstyle: { // deprecated
-            default: mj.options.speakStyle,
-            describe: "style to use for speech text (default, brief, sbrief)"
-        },
         linebreaks: {
             boolean: true,
             describe: "perform automatic line-breaking"
@@ -120,20 +112,16 @@ const mjconf = {
 const mjinput = {
     math: argv._[0],
     format: argv.format,
-    svg: (argv.output === 'svg'),
-    html: (argv.output === 'html'),
     css: argv.css,
-    mml: (argv.output === 'mml'),
     speakText: argv.speech,
-    speakRuleset: argv.speechrules.replace(/^chromevox$/i, "default"),
-    speakStyle: argv.speechstyle,
     ex: argv.ex,
     width: argv.width,
     linebreaks: argv.linebreaks,
     sre: argv.sre
 };
 
-console.log(argv._[0])
+mjinput[argv.output] = true;
+
 const output = function(result) {
     if (result.errors) console.log(result.errors);
     else if (argv.css) console.log(result.css);

--- a/bin/mjsre.js
+++ b/bin/mjsre.js
@@ -25,15 +25,20 @@ const argv = require("yargs")
     .options({
         speech: {
             boolean: true,
-            default: true,
+            default: mj.options.speak,
             describe: "include speech text"
         },
-        speechrules: {
-            default: "mathspeak",
+        sre: {
+            array: true,
+            nargs: 2,
+            describe: "SRE flags as key value pairs"
+        },
+        speechrules: { // deprecated
+            default: mj.options.speakRules,
             describe: "ruleset to use for speech text (chromevox or mathspeak)"
         },
-        speechstyle: {
-            default: "default",
+        speechstyle: { // deprecated
+            default: mj.options.speakStyle,
             describe: "style to use for speech text (default, brief, sbrief)"
         },
         linebreaks: {
@@ -41,11 +46,11 @@ const argv = require("yargs")
             describe: "perform automatic line-breaking"
         },
         format: {
-            default: "TeX",
+            default: mj.options.format,
             describe: "input format(s) to look for"
         },
         font: {
-            default: "TeX",
+            default: mj.options.font,
             describe: "web font to use"
         },
         inline: {
@@ -61,24 +66,24 @@ const argv = require("yargs")
             describe: "For TeX input and MathML output, don't add TeX-specific classes"
         },
         output: {
-            default: "SVG",
+            default: mj.options.output,
             describe: "output format (SVG, CommonHTML, or MML)",
             coerce: (x => {return x.toLowerCase();})
         },
         ex: {
-            default: 6,
+            default: mj.options.ex,
             describe: "ex-size in pixels"
         },
         width: {
-            default: 100,
+            default: mj.options.width,
             describe: "width of equation container in ex (for line-breaking)"
         },
         extensions: {
-            default: "",
+            default: mj.options.extensions,
             describe: "extra MathJax extensions e.g. 'Safe,TeX/noUndefined'"
         },
         fontURL: {
-            default: "https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS",
+            default: mj.options.fontURL,
             describe: "the URL to use for web fonts"
         },
         css: {
@@ -124,16 +129,17 @@ const mjinput = {
     speakStyle: argv.speechstyle,
     ex: argv.ex,
     width: argv.width,
-    linebreaks: argv.linebreaks
-}
+    linebreaks: argv.linebreaks,
+    sre: argv.sre
+};
 
 console.log(argv._[0])
 const output = function(result) {
     if (result.errors) console.log(result.errors);
     else if (argv.css) console.log(result.css);
     else console.log(result[argv.output]);
-}
+};
 
 mj.config(mjconf);
 mj.start();
-mj.typeset(mjinput, output)
+mj.typeset(mjinput, output);

--- a/lib/main.js
+++ b/lib/main.js
@@ -21,6 +21,48 @@ const sre = require('speech-rule-engine');
 // speakText:                      // string with spoken annotation
 
 
+const optionsDefault = {
+    speak: true,
+    speakRules: "mathspeak",
+    speakStyle: "default",
+    format: "TeX",
+    font: "TeX",
+    output: "SVG",
+    ex: 6,
+    width: 100,
+    extensions: "",
+    enrich: false,
+    semantic: false,
+    fontURL: "https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS"
+};
+
+const sreDefault = {
+    speech: 'deep',
+    semantics: true,
+    domain: 'mathspeak',
+    style: 'default'
+};
+
+
+const sreconfig = function(data) {
+    let config = {
+        // TODO: remove as deprecated!
+        domain: data.speakRules || 'mathspeak',
+        style: data.speakStyle || 'default',
+        // TODO: What does that do?
+        minSTree: data.minSTree
+    };
+    if (data.sre) {
+        for (let i = 0, key; key = data.sre[i]; i++) {
+            let value = data.sre[++i];
+            config[key] = value || false;
+        }
+    }
+    Object.assign(sreDefault, config);
+    return config;
+};
+
+
 const main = function (data, callback) {
     const speechConfig = {
         speech: data.speech ||'deep',
@@ -138,6 +180,7 @@ const preprocessor = function (data, callback) {
 }
 
 
+exports.options = optionsDefault;
 exports.start = mathjax.start;
 exports.config = mathjax.config;
 const cbTypeset = function (data, callback) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -4,12 +4,14 @@ const sre = require('speech-rule-engine');
 // New configuration values are:
 //
 // speakText: true,               // adds spoken annotations to output
-// speakRuleset: "mathspeak",      // set speech ruleset; default (= chromevox rules) or mathspeak
-// speakStyle: "default",          // set speech style for mathspeak rules:  default, brief, sbrief)
-// semantic: false,                // adds semantic tree information to output
-// minSTree: false,                // if true the semantic tree is minified
 // enrich: false                   // replace the math input with MathML resulting from SRE enrichment
-// speech: 'deep'                  // sets depth of speech; 'shallow' or 'deep'
+// output: SVG
+//    Other values are
+//        MML (Mathml), HTML (common HTML), speech (Speech string only)
+//        Stree (semantic tree), json (semantic tree in json format)
+//    Each of these values can also be simply given as flag in the configuration object.
+//    Resulting values are then in the result object.
+// 
 
 // How to use them:
 // in main, pre-processor: the `data` parameter is the usual mathjax-node configuration object, with (possibly) the above additions.
@@ -23,8 +25,6 @@ const sre = require('speech-rule-engine');
 
 const optionsDefault = {
     speakText: true,
-    speakRules: "mathspeak",
-    speakStyle: "default",
     format: "TeX",
     font: "TeX",
     output: "SVG",
@@ -45,15 +45,7 @@ const sreDefault = {
 
 
 const sreconfig = function(data) {
-    let config = {
-        // TODO: remove as deprecated!
-        semantics: true,
-        domain: data.speakRules || 'mathspeak',
-        style: data.speakStyle || 'default',
-        // TODO: What does that do?
-        minSTree: data.minSTree,
-        semantic: data.semantic
-    };
+    let config = {};
     if (data.sre) {
         for (let i = 0, key; key = data.sre[i]; i++) {
             let value = data.sre[++i];
@@ -61,7 +53,6 @@ const sreconfig = function(data) {
         }
     }
     return Object.assign({}, sreDefault, config);
-    // return config;
 };
 
 
@@ -79,10 +70,9 @@ const main = function (data, callback) {
     if (data.html) data.htmlNode = true;
     data.mmlNode = true;
     data.mml = true;
-
     mathjax.typeset(data, function (result, input) {
         postprocessor(data, result, input, callback);
-    })
+    });
 };
 
 const postprocessor = function (data, result, input, callback) {
@@ -93,21 +83,23 @@ const postprocessor = function (data, result, input, callback) {
     if (!result.mml) result.mml = result.mmlNode.outerHTML;
     if (!speechConfig.speech) speechConfig.speech =  'deep';
     // add semantic tree
-    if (speechConfig.semantic) {
-        result.streeJson = sre.toJson(result.mml);
+    if (data.json) {
+        result.json = sre.toJson(result.mml);
+    }
+    if (data.stree) {
         const xml = sre.toSemantic(result.mml).toString();
-        result.streeXml = speechConfig.minSTree ? xml : sre.pprintXML(xml);
+        result.stree = sre.pprintXML(xml);  // Make pretty printing an option of SRE.
     }
     // return if no speakText is requested
     if (!data.speakText) {
         callback(result, input);
-        return
+        return;
     }
     // enrich output
     sre.setupEngine(speechConfig);
-    result.speakText = sre.toSpeech(result.mml);
+    result.speech = sre.toSpeech(result.mml);
     if (result.svgNode) {
-        result.svgNode.querySelector('title').innerHTML = result.speakText;
+        result.svgNode.querySelector('title').innerHTML = result.speech;
         // update serialization
         // HACK add lost xlink namespaces TODO file jsdom bug
         if (result.svg) result.svg = result.svgNode.outerHTML
@@ -116,12 +108,12 @@ const postprocessor = function (data, result, input, callback) {
             .replace(/(<(?:use|image) [^>]*)(href=)/g, ' $1xlink:$2');
     }
     if (result.htmlNode) {
-        result.htmlNode.firstChild.setAttribute("aria-label", result.speakText);
+        result.htmlNode.firstChild.setAttribute("aria-label", result.speech);
         // update serialization
         if (result.html) result.html = result.htmlNode.outerHTML;
     }
     if (result.mmlNode) {
-        result.mmlNode.setAttribute("alttext", result.speakText);
+        result.mmlNode.setAttribute("alttext", result.speech);
         // update serialization
         if (result.mml) result.mml = result.mmlNode.outerHTML;
     }
@@ -138,7 +130,6 @@ const postprocessor = function (data, result, input, callback) {
 
 const preprocessor = function (data, callback) {
     const speechConfig = sreconfig(data);
-    if (data.speakText === false) speechConfig.speakText = false
     sre.setupEngine(speechConfig);
     // if MathML, enrich and continue
     if (data.format === "MathML") {

--- a/lib/main.js
+++ b/lib/main.js
@@ -47,10 +47,13 @@ const sreDefault = {
 const sreconfig = function(data) {
     let config = {
         // TODO: remove as deprecated!
+        semantics: true,
         domain: data.speakRules || 'mathspeak',
         style: data.speakStyle || 'default',
         // TODO: What does that do?
-        minSTree: data.minSTree
+        minSTree: data.minSTree,
+        semantic: data.semantic,
+        speakText: true
     };
     if (data.sre) {
         for (let i = 0, key; key = data.sre[i]; i++) {
@@ -58,29 +61,20 @@ const sreconfig = function(data) {
             config[key] = value || false;
         }
     }
-    Object.assign(sreDefault, config);
-    return config;
+    return Object.assign({}, sreDefault, config);
+    // return config;
 };
 
 
 const main = function (data, callback) {
-    const speechConfig = {
-        speech: data.speech ||'deep',
-        semantics: true,
-        domain: data.speakRuleset || 'mathspeak',
-        style: data.speakStyle || 'default',
-        semantic: data.semantic,
-        minSTree: data.minSTree,
-        speakText: true
-    };
-    if (data.speakText === false) speechConfig.speakText = false;
+    const speechConfig = sreconfig(data);
     // backup data
     data.originalData = {
         mml: data.mml,
         mmlNode: data.mmlNode,
         svgNode: data.svgNode,
         htmlNode: data.htmlNode
-    }
+    };
     // modify configuration
     if (data.svg) data.svgNode = true;
     if (data.html) data.htmlNode = true;
@@ -143,16 +137,7 @@ const postprocessor = function (speechConfig, result, input, callback) {
 }
 
 const preprocessor = function (data, callback) {
-    // setup SRE
-    const speechConfig = {
-        semantics: true,
-        domain: data.speakRuleset || 'mathspeak',
-        style: data.speakStyle || 'default',
-        semantic: data.semantic,
-        minSTree: data.minSTree,
-        speakText: true,
-        speech: 'deep'
-    };
+    const speechConfig = sreconfig(data);
     if (data.speakText === false) speechConfig.speakText = false
     sre.setupEngine(speechConfig);
     // if MathML, enrich and continue
@@ -192,9 +177,12 @@ const cbTypeset = function (data, callback) {
 };
 // main API, callback and promise compatible
 exports.typeset = function (data, callback) {
-    if (callback) cbTypeset(data, callback);
+    let mjConfig = Object.assign({}, optionsDefault, data);
+    if (callback) {
+        cbTypeset(mjConfig, callback);
+    }
     else return new Promise(function (resolve, reject) {
-        cbTypeset(data, function (output, input) {
+        cbTypeset(mjConfig, function (output, input) {
             if (output.errors) reject(output.errors);
             else resolve(output, input);
         });

--- a/lib/main.js
+++ b/lib/main.js
@@ -22,7 +22,7 @@ const sre = require('speech-rule-engine');
 
 
 const optionsDefault = {
-    speak: true,
+    speakText: true,
     speakRules: "mathspeak",
     speakStyle: "default",
     format: "TeX",
@@ -52,8 +52,7 @@ const sreconfig = function(data) {
         style: data.speakStyle || 'default',
         // TODO: What does that do?
         minSTree: data.minSTree,
-        semantic: data.semantic,
-        speakText: true
+        semantic: data.semantic
     };
     if (data.sre) {
         for (let i = 0, key; key = data.sre[i]; i++) {
@@ -82,11 +81,12 @@ const main = function (data, callback) {
     data.mml = true;
 
     mathjax.typeset(data, function (result, input) {
-        postprocessor(speechConfig, result, input, callback);
+        postprocessor(data, result, input, callback);
     })
 };
 
-const postprocessor = function (speechConfig, result, input, callback) {
+const postprocessor = function (data, result, input, callback) {
+    let speechConfig = sreconfig(data);
     if (result.error) throw result.error;
     if (!result.mml && !result.mmlNode) throw new Error('No MathML found. Please check the mathjax-node configuration');
     if (!result.svgNode && !result.htmlNode && !result.mmlNode) throw new Error('No suitable output found. Either svgNode, htmlNode or mmlNode are required.');
@@ -99,7 +99,7 @@ const postprocessor = function (speechConfig, result, input, callback) {
         result.streeXml = speechConfig.minSTree ? xml : sre.pprintXML(xml);
     }
     // return if no speakText is requested
-    if (!speechConfig.speakText) {
+    if (!data.speakText) {
         callback(result, input);
         return
     }

--- a/test/base-semantictree.js
+++ b/test/base-semantictree.js
@@ -8,10 +8,10 @@ tape('Base check: speech-rule-engine semanticTree', function(t) {
     math: tex,
     format: "TeX",
     mml: true,
-    speakText: true,
-    semantic: true
+    stree: true,
+    json: true
   }, function(data) {
-    t.ok(data.streeJson, 'semantic tree JSON');
-    t.ok(data.streeXml, 'semantic tree XML');
+    t.ok(data.json, 'semantic tree JSON');
+    t.ok(data.stree, 'semantic tree XML');
   });
 });


### PR DESCRIPTION
This is a partial rewrite of the package. It allows to directly push all options available in SRE via `setupEngine` using the `--sre` command line option or alternatively a pair list in the configuration object.
In addition it:
* Separates configuration for SRE and MJ-node. Now uses two separate default configuration objects.
* Introduces a more generic handling of output options.
* Allows to compute speech only  on the command line. Similarly for JSON and XML versions of the semantic tree. 
* Deprecates options like `speechrules` and `speechstyle`
